### PR TITLE
Compile and report on all errors in getSiteId()

### DIFF
--- a/FourCePhase2.1Data/R/inputFileFunctions.R
+++ b/FourCePhase2.1Data/R/inputFileFunctions.R
@@ -54,23 +54,31 @@ getSiteId <- function() {
     )
 
     siteId = NA
+    
+    # Compile errors into a list.
+    errors = list()
 
     ## for each file pattern we are supposed to match
     for (currFNamePattern in fNamePatterns) {
 
         ix = grep(pattern=currFNamePattern, x=fNames)
 
-        ## if no match, stop
+        # Note if we find no match.
         if (length(ix) == 0) {
-            stop("No match found for file name pattern: ", currFNamePattern)
+            errors[[currFNamePattern]] =
+                paste("No match found for file name pattern:", currFNamePattern)
+            next
         }
 
-        ## if multiple matches, stop
+        # Note if we find multiple matches
         if (length(ix) > 1) {
-            stop("Multiple matches found for file name pattern: ", currFNamePattern, ": ", paste(fNames[ix], collapse=", "))
+            errors[[currFNamePattern]] =
+                paste("Multiple matches found for file name pattern: ",
+                      currFNamePattern, ": ", paste(fNames[ix], collapse=", "))
+            next
         }
 
-        ## so we have exactly one match, make sure all files are named for the same site ID
+        # So we have exactly one match, make sure all files are named for the same site ID
         prefixSuffix = strsplit(x=currFNamePattern, split=".+\\", fixed=TRUE)[[1]]
         currSiteId = 
             gsub(
@@ -88,9 +96,17 @@ getSiteId <- function() {
         }
 
         if (siteId != currSiteId) {
-            stop("Files for multiple sites found in the input data directory: ", siteId, ", ", currSiteId)
+            errors[[currFNamePattern]] =
+                paste0("Files for multiple sites found in the input data directory: ",
+                       siteId, ", ", currSiteId)
         }
     }
-
+    
+    if (length(errors) > 0) {
+        cat("Error(s) found in getSiteId():\n")
+        cat(" *", paste(unname(errors), collapse = "\n * "), "\n")
+        stop("Could not complete getSiteId(). See https://github.com/covidclinical/Phase2.1DataRPackage for help.")
+    }
+    
     return(siteId)
 }


### PR DESCRIPTION
Hello,

This is a PR that revises getSiteId() to compile all errors and report them at the end, rather than stop at the first error. I found it a little time consuming when I was initially getting my 4CE data setup to get the incremental errors, so I believe this could be a helpful revision for others as well. Happy to make any changes if desired.

This is what the output looks like before making any revisions to the BIDMC data exports:

```
Error(s) found in getSiteId():
 * No match found for file name pattern: Labs-.+\.csv
 * No match found for file name pattern: Medications-.+\.csv
 * No match found for file name pattern: Diagnoses-.+\.csv
 * No match found for file name pattern: Demographics-.+\.csv
 * No match found for file name pattern: DailyCounts-.+\.csv
 * No match found for file name pattern: ClinicalCourse-.+\.csv 
Error in FourCePhase2.1Data::getSiteId() : 
  Could not complete getSiteId(). See https://github.com/covidclinical/Phase2.1DataRPackage for help.
```

Thanks,
Chris